### PR TITLE
Feature/initialize with options

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           repository: approov/core-service-layers-testing
           token: ${{ secrets.CORE_SERVICE_LAYERS_TESTING_PAT }}
+          ref: 1dbc1bba2135f20cd7a9868ac2eeea881906310c  # pin to vetted commit; update when pulling in new testing framework changes
           path: core-service-layers-testing
 
       # -----------------------------------------------------------------------

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,197 @@
+name: Build and Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      WORKSPACE: "${{ github.workspace }}"
+      GIT_BRANCH: "${{ github.ref }}"
+      CURRENT_TAG: "${{ github.ref_name }}"
+      # Worker endpoints: consumed from GitHub organisation variables first.
+      # If the org variable is not set the value is an empty string; the probe
+      # step below falls back to the same hardcoded defaults that are baked into
+      # the mini-sdk (MiniAttesterConfig / Approov.m), keeping them in sync.
+      # Worker management (create / redeploy) logic is centralized in the
+      # core-service-layers-testing script, but invoked here when needed.
+      TESTING_REPLY_URL: ${{ vars.TESTING_REPLY_URL }}
+      TESTING_REPLY_URL_UNPROTECTED: ${{ vars.TESTING_REPLY_URL_UNPROTECTED }}
+      # Required for the redeploy script invocation on failure
+      CLOUDFLARE_API_TOKEN_WORKERS_DEV: ${{ secrets.CLOUDFLARE_API_TOKEN_WORKERS_DEV }}
+      CLOUDFLARE_ACCOUNT_ID_WORKERS_DEV: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_WORKERS_DEV }}
+      # iOS Mini-SDK configuration for Package.swift
+      APPROOV_USE_MINI_SDK: "1"
+      APPROOV_MINI_SDK_PATH: "../core-service-layers-testing/mini-sdk/ios"
+
+    steps:
+      # -----------------------------------------------------------------------
+      # 1. Checkout this repository
+      # -----------------------------------------------------------------------
+      - name: Set up Git
+        run: git config --global --add safe.directory '*'
+
+      - name: Checkout approov-service-alamofire
+        uses: actions/checkout@v5
+        with:
+          path: approov-service-alamofire
+
+      # -----------------------------------------------------------------------
+      # 2. Clone core-service-layers-testing as a sibling directory
+      #    Package.swift expects: ../core-service-layers-testing/...
+      #    so both repos must sit under the same parent ($GITHUB_WORKSPACE).
+      # -----------------------------------------------------------------------
+      - name: Checkout core-service-layers-testing
+        uses: actions/checkout@v5
+        with:
+          repository: approov/core-service-layers-testing
+          token: ${{ secrets.CORE_SERVICE_LAYERS_TESTING_PAT }}
+          path: core-service-layers-testing
+
+      # -----------------------------------------------------------------------
+      # 3. Verify worker endpoints (with auto-redeploy)
+      #
+      #    URLs are resolved with the following precedence (mirrors the mini-sdk
+      #    fallback logic in MiniAttesterConfig / Approov.m):
+      #      1. GitHub org variable  (TESTING_REPLY_URL / _UNPROTECTED)
+      #      2. Mini-SDK hardcoded defaults (replay.ivol.workers.dev / ...)
+      #
+      #    If the workers are unavailable, this step invokes the management
+      #    script in core-service-layers-testing to redeploy them.
+      # -----------------------------------------------------------------------
+      - name: Verify worker endpoints
+        run: |
+          # ── URL resolution ──────────────────────────────────────────────────
+          PROTECTED_URL="${TESTING_REPLY_URL:-https://replay.ivol.workers.dev}"
+          UNPROTECTED_URL="${TESTING_REPLY_URL_UNPROTECTED:-https://replay-unprotected.ivol.workers.dev}"
+          
+          echo "TESTING_REPLY_URL=$PROTECTED_URL"       >> "$GITHUB_ENV"
+          echo "TESTING_REPLY_URL_UNPROTECTED=$UNPROTECTED_URL" >> "$GITHUB_ENV"
+
+          # ── Probe function ──────────────────────────────────────────────────
+          probe_worker() {
+            local url="$1"
+            curl --silent --show-error --fail --max-time 10 \
+              -X POST "$url" \
+              -H "Content-Type: application/json" \
+              -d '{"check":"probe"}' | grep -q '"body"'
+          }
+
+          echo "==> Probing workers..."
+          if probe_worker "$PROTECTED_URL" && probe_worker "$UNPROTECTED_URL"; then
+            echo "    All workers are healthy."
+            exit 0
+          fi
+
+          echo "    WARNING: One or more workers are down. Attempting redeploy..."
+          
+          # ── Invoke redeploy script ──────────────────────────────────────────
+          # The script is in the sibling directory cloned in Step 2.
+          # It uses the CLOUDFLARE_* env variables defined at the job level.
+          ./core-service-layers-testing/cloudflare-workers/redeploy-workers.sh
+
+          echo "==> Verifying after redeploy..."
+          # Try up to 3 times with a 5s delay between attempts
+          for i in {1..3}; do
+            if probe_worker "$PROTECTED_URL" && probe_worker "$UNPROTECTED_URL"; then
+              echo "    Workers successfully restored."
+              exit 0
+            fi
+            echo "    Waiting for propagation (attempt $i/3)..."
+            sleep 5
+          done
+
+          echo "ERROR: Workers are still unreachable after redeployment effort."
+          exit 1
+
+      # -----------------------------------------------------------------------
+      # 5. Build and run tests
+      #    Swift is invoked from inside the checked-out service directory.
+      #    The mini-sdk is already available via the sibling path wired into
+      #    Package.swift — no extra configuration needed here.
+      # -----------------------------------------------------------------------
+      - name: Build and Test (SwiftPM)
+        working-directory: approov-service-alamofire
+        env:
+          TESTING_REPLY_URL: ${{ env.TESTING_REPLY_URL }}
+          TESTING_REPLY_URL_UNPROTECTED: ${{ env.TESTING_REPLY_URL_UNPROTECTED }}
+        run: |
+          set -o pipefail
+          swift test --verbose 2>&1 | tee test_output.txt
+
+      # -----------------------------------------------------------------------
+      # 6. Print test summary
+      #    Parses the Swift test output captured in the previous step.
+      # -----------------------------------------------------------------------
+      - name: Print test summary
+        if: always()
+        working-directory: approov-service-alamofire
+        run: |
+          python3 - <<'EOF'
+          import os, sys, re
+
+          PASS  = "\u2705"
+          FAIL  = "\u274c"
+          SKIP  = "\u23ed\ufe0f"
+
+          output_path = "test_output.txt"
+          if not os.path.exists(output_path):
+              print("No test output found.")
+              sys.exit(1)
+
+          with open(output_path, "r") as f:
+              lines = f.readlines()
+
+          # Regex for Swift/XCTest output:
+          # Test Case '-[Suite.TestClass testName]' passed (0.123 seconds).
+          test_re = re.compile(r"Test Case '-\[(?P<suite>[^. ]+)\.(?P<class>[^ ]+) (?P<name>[^\]]+)\]' (?P<status>passed|failed) \((?P<time>[0-9.]+) seconds\)")
+          
+          results = []
+          for line in lines:
+              match = test_re.search(line)
+              if match:
+                  results.append({
+                      "name": match.group("name"),
+                      "class": match.group("class"),
+                      "status": match.group("status"),
+                      "time": float(match.group("time"))
+                  })
+
+          if not results:
+              print("No tests were detected in the output.")
+              # If we saw "0 tests passed" in the log, let's look for why.
+              sys.exit(1)
+
+          total = len(results)
+          passed = sum(1 for r in results if r["status"] == "passed")
+          failed = total - passed
+          overall_ok = (failed == 0)
+
+          # ── Console output ──────────────────────────────────────────────────
+          icon = PASS if overall_ok else FAIL
+          print()
+          print(f"{'='*70}")
+          print(f"  {icon}  Swift Test Summary  |  {passed}/{total} passed  |  {failed} failed")
+          print(f"{'='*70}")
+          for r in results:
+              print(f"  {PASS if r['status'] == 'passed' else FAIL}  {r['name']:<55} ({r['time']:.3f}s)")
+          print()
+
+          # ── GitHub Job Summary (markdown) ───────────────────────────────────
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+          if summary_path:
+              with open(summary_path, "a") as md:
+                  badge = "\U0001f7e2 PASSED" if overall_ok else "\U0001f534 FAILED"
+                  md.write(f"### Swift Tests &nbsp; {badge}\n\n")
+                  md.write(f"> **{passed} passed** &nbsp;|&nbsp; **{failed} failed** &nbsp;|&nbsp; **{total} total**\n\n")
+                  md.write("| Status | Test Case | Time |\n")
+                  md.write("|--------|-----------|-----:|\n")
+                  for r in results:
+                      icon = "\U0001f7e2" if r["status"] == "passed" else "\U0001f534"
+                      md.write(f"| {icon} | `{r['name']}` | {r['time']:.3f}s |\n")
+
+          sys.exit(0 if overall_ok else 1)
+          EOF

--- a/Package.swift
+++ b/Package.swift
@@ -1,44 +1,72 @@
 // swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+import Foundation
 import PackageDescription
 // Release tag
 let releaseTAG = "3.5.5"
 // SDK package version (used for both iOS and watchOS)
-let sdkVersion = "3.5.3"
+let sdkVersion: Version = "3.5.3"
+let useMiniSDK = ProcessInfo.processInfo.environment["APPROOV_USE_MINI_SDK"] == "1"
+let miniSDKPath = ProcessInfo.processInfo.environment["APPROOV_MINI_SDK_PATH"] ?? "../core-service-layers-testing/mini-sdk/ios"
+
+let approovPackageName = useMiniSDK ? "mini-sdk-ios" : "approov-ios-sdk"
+let packagePlatforms: [SupportedPlatform] = useMiniSDK
+    ? [
+        .iOS(.v11),
+        .watchOS(.v9),
+        .macOS(.v13),
+    ]
+    : [
+        .iOS(.v11),
+        .watchOS(.v9),
+    ]
+var packageDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.2.0")),
+    .package(url: "https://github.com/apple/swift-http-structured-headers.git", from: "1.0.0"),
+]
+if useMiniSDK {
+    packageDependencies.append(.package(name: "mini-sdk-ios", path: miniSDKPath))
+} else {
+    packageDependencies.append(.package(url: "https://github.com/approov/approov-ios-sdk.git", exact: sdkVersion))
+}
+
+var packageTargets: [Target] = [
+    .target(
+        name: "ApproovAFSession",
+        dependencies: [
+            .product(name: "Approov", package: approovPackageName),
+            .product(name: "Alamofire", package: "Alamofire"),
+            .product(name: "RawStructuredFieldValues", package: "swift-http-structured-headers")
+        ],
+        path: "Sources/ApproovSession",
+        exclude: ["README.md", "LICENSE"]
+    )
+]
+
+if useMiniSDK {
+    packageTargets.append(
+        .testTarget(
+            name: "ApproovAFSessionMiniSDKTests",
+            dependencies: [
+                "ApproovAFSession",
+                .product(name: "Approov", package: "mini-sdk-ios"),
+                .product(name: "MiniSDKTestSupport", package: "mini-sdk-ios")
+            ],
+            path: "Tests/ApproovAFSessionMiniSDKTests"
+        )
+    )
+}
 
 let package = Package(
     name: "ApproovAFSession",
-    platforms: [
-        .iOS(.v11),
-        .watchOS(.v9)
-    ],
+    platforms: packagePlatforms,
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "ApproovAFSession",
             targets: ["ApproovAFSession"]
         ),
         .library(name: "ApproovAFSessionDynamic", type: .dynamic, targets: ["ApproovAFSession"])
     ],
-    dependencies: [
-        // Package's external dependencies and from where they can be fetched:
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.2.0")),
-        .package(url: "https://github.com/apple/swift-http-structured-headers.git", from: "1.0.0"),
-        // Force-unwrapping is safe here because sdkVersion is a valid semantic version string
-        .package(url: "https://github.com/approov/approov-ios-sdk.git", from: Version(sdkVersion)!)
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "ApproovAFSession",
-            dependencies: [
-                .product(name: "Approov", package: "approov-ios-sdk"),
-                .product(name: "Alamofire", package: "Alamofire"),
-                .product(name: "RawStructuredFieldValues", package: "swift-http-structured-headers")
-            ],
-            path: "Sources/ApproovSession",  // Point to the shared source code
-            exclude: ["README.md", "LICENSE"]
-        )
-    ]
+    dependencies: packageDependencies,
+    targets: packageTargets
 )

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,15 +1,18 @@
+# Security Policy
 
-We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionalities than later versions. 
+## Supported Versions
+
+We maintain updates and patches in the latest release. Earlier versions will still work, but will have fewer functionalities than later versions.
 We encourage all users of these service layers to update to the latest version for the best experience.
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 3.5.x   | :white_check_mark: |
-| < 3.4   | :x:                |
+| < 3.5.0 | :x:                |
 
 ## Reporting a Vulnerability
 
-Thank you for letting us know about possible security vulnerabilities to this project. 
-Please don’t publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to. 
+Thank you for letting us know about possible security vulnerabilities in this project.
+Please don't publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to.
 
-Your message will recieve a prompt reply. 
+Your message will receive a prompt reply.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-We maintain updates and patches in the latest release. Earlier versions will still work, but will have fewer functionalities than later versions.
+We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionality than later versions.
 We encourage all users of these service layers to update to the latest version for the best experience.
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 3.5.x   | :white_check_mark: |
-| < 3.5.0 | :x:                |
+| < 3.5.0 (3.4.0) | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+
+We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionalities than later versions. 
+We encourage all users of these service layers to update to the latest version for the best experience.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.5.x   | :white_check_mark: |
+| < 3.4   | :x:                |
+
+## Reporting a Vulnerability
+
+Thank you for letting us know about possible security vulnerabilities to this project. 
+Please don’t publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to. 
+
+Your message will recieve a prompt reply. 

--- a/Sources/ApproovSession/ApproovService.swift
+++ b/Sources/ApproovSession/ApproovService.swift
@@ -91,8 +91,11 @@ public class ApproovService {
     // configuration string used for initialization
     private static var configString: String?
 
-    // status of Approov SDK initialization
-    private static var isInitialized = false
+    // status of service layer initialization
+    private static var serviceIsInitialized = false
+
+    // whether the native Approov SDK has been successfully initialized with a non-empty config
+    private static var approovEnabled = false
 
     // the dispatch queue to manage serial access to other ApproovService state
     private static let stateQueue = DispatchQueue(label: "ApproovService.state", qos: .userInitiated)
@@ -138,52 +141,100 @@ public class ApproovService {
     private static var exclusionURLRegexs: Dictionary<String, NSRegularExpression> = Dictionary()
     
     /**
+     * Returns whether the service layer has been initialized. Returns true even for
+     * empty-config bypass mode.
+     *
+     * @return true if the service layer has been initialized
+     */
+    public static func isInitialized() -> Bool {
+        return initializerQueue.sync { serviceIsInitialized }
+    }
+
+    /**
+     * Returns whether Approov protection is currently enabled. Returns true only when
+     * the service layer has been initialized with a valid, non-empty configuration string.
+     *
+     * @return true if Approov protection is active
+     */
+    public static func isApproovEnabled() -> Bool {
+        return initializerQueue.sync { approovEnabled }
+    }
+
+    /**
      * Initializes the SDK with the config obtained using `approov sdk -getConfigString` or
-     * in the original onboarding email. Note the initializer function should only ever be called once.
-     * Subsequent calls will be ignored since the ApproovSDK can only be initialized once; if however,
-     * an attempt is made to initialize with a different configuration (config) we throw an
-     * ApproovException.configurationError. If the Approov SDK fails to be initialized for some other
-     * reason, an .initializationError is raised.
+     * in the original onboarding email. The service layer resets its own configuration state
+     * on a successful call. If using a non-empty config, the platform SDK is contacted first;
+     * state is only modified after the SDK confirms success, preserving the current operating
+     * mode (protected or bypass) if the call fails.
      *
      * @param config is the configuration to be used, or an empty string to bypass the actual initialization
      * @param comment is an optional comment to be passed to the SDK
      * @throws ApproovError if there was a problem
      */
     public static func initialize(config: String, comment: String? = nil) throws {
-        try initializerQueue.sync  {
-            // check if we attempt to use a different configString
-            if isInitialized && ((comment?.hasPrefix("reinit")) == nil) {
-                // ignore multiple initialization calls that use the same configuration
-                if (config != configString) {
-                    // throw exception indicating we are attempting to use different config
-                    if loggingLevel >= .error {
-                        os_log("ApproovService: Attempting to initialize with different configuration", type: .error)
-                    }
-                    throw ApproovError.configurationError(message: "Attempting to initialize with a different configuration")
+        try initializerQueue.sync {
+            // If we are already initialized with a valid config, ignore any subsequent
+            // attempt to initialize with an empty config (cannot downgrade from protected
+            // to bypass mode).
+            if approovEnabled && config.isEmpty {
+                if loggingLevel >= .info {
+                    os_log("ApproovService: ignoring empty config after valid initialization", type: .info)
                 }
-                if loggingLevel >= .warning {
-                    os_log("ApproovService: Ignoring multiple ApproovService layer initializations with the same config");
-                }
-            } else {
+                return
+            }
+
+            // Forward all non-empty configs to the native SDK without filtering.
+            // The service layer must not intercept, filter, or short-circuit calls
+            // based on its internal state (spec §1 line 25).
+            if !config.isEmpty {
                 do {
-                    if !config.isEmpty {
-                        // only initialize with a non-empty string as empty string used to bypass this
-                        try Approov.initialize(config, updateConfig: "auto", comment: comment)
-                    }
+                    try Approov.initialize(config, updateConfig: "auto", comment: comment)
                 } catch let error {
-                    // If the error is due to the SDK being initialized already, we ignore it otherwise we throw
+                    // The Swift/Objective-C bridge translates a BOOL=NO return into
+                    // a thrown error with code 0 and domain Foundation._GenericObjCError.
+                    // This indicates "already initialized with the same config" — a benign
+                    // outcome that we treat as success.
                     let nsError = error as NSError
                     if nsError.code == 0, nsError.domain == "Foundation._GenericObjCError" {
-                        if loggingLevel >= .error {
-                            os_log("ApproovService: Ignoring initialization error in Approov SDK: %@", type: .error, nsError.localizedDescription)
+                        if loggingLevel >= .info {
+                            os_log("ApproovService: native SDK already initialized (same config): %@", type: .info, nsError.localizedDescription)
                         }
                     } else {
+                        // Real failure — leave service-layer state completely unchanged
+                        if loggingLevel >= .error {
+                            os_log("ApproovService: initialization failed: %@", type: .error, nsError.localizedDescription)
+                        }
                         throw ApproovError.initializationError(message: "Error initializing Approov SDK: \(nsError.localizedDescription)")
                     }
                 }
-                isInitialized = true
-                configString = config
+            }
+
+            // SDK succeeded (or bypass) — now reset and commit new service-layer state.
+            serviceIsInitialized = false
+            configString = config
+            stateQueue.sync {
+                bindingHeader = ""
+                approovTokenHeader = "Approov-Token"
+                approovTokenPrefix = ""
+                approovTraceIDHeader = "Approov-TraceID"
+                serviceMutator = ApproovServiceMutatorDefault.shared
+                substitutionHeaders = Dictionary()
+                substitutionQueryParams = Set()
+                exclusionURLRegexs = Dictionary()
+                useApproovStatusIfNoToken = false
+            }
+            serviceIsInitialized = true
+            if !config.isEmpty {
+                approovEnabled = true
                 Approov.setUserProperty("approov-service-alamofire")
+                if loggingLevel >= .info {
+                    os_log("ApproovService: initialized with Approov protection enabled", type: .info)
+                }
+            } else {
+                approovEnabled = false
+                if loggingLevel >= .info {
+                    os_log("ApproovService: initialized in bypass mode (empty config)", type: .info)
+                }
             }
         }
     }
@@ -194,6 +245,12 @@ public class ApproovService {
      * @return String of the last ARC or empty string if there was none
      */
     public static func getLastARC() -> String {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getLastARC: SDK not initialized", type: .error)
+            }
+            return ""
+        }
         // We have to get the current config and obtain one protected API endpoint at least
         // get the dynamic pins from Approov
         guard let approovPins = Approov.getPins("public-key-sha256") else {
@@ -204,14 +261,13 @@ public class ApproovService {
         }
         // The approovPins contains a map of hostnames to pin strings.  We need to skip the '*' entry (Managed Trust Roots),
         // and use another hostname if available.
-            if let hostname = approovPins.keys.first(where: { $0 != "*" }) {
-                let result = Approov.fetchTokenAndWait(hostname)
-                // Check if a token was fetched successfully and return its arc code
-                if result.token.count > 0 {
-                    return result.arc
-                }
+        if let hostname = approovPins.keys.first(where: { $0 != "*" }) {
+            let result = Approov.fetchTokenAndWait(hostname)
+            // Check if a token was fetched successfully and return its arc code
+            if result.token.count > 0 {
+                return result.arc
             }
-        
+        }
         if loggingLevel >= .info {
             os_log("ApproovService: ARC code unavailable", type: .info)
         }
@@ -229,6 +285,12 @@ public class ApproovService {
      * @param devKey is the development key to be used
      */
     public static func setDevKey(devKey: String) {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: setDevKey: SDK not initialized", type: .error)
+            }
+            return
+        }
         stateQueue.sync {
             Approov.setDevKey(devKey)
             if loggingLevel >= .debug {
@@ -534,7 +596,7 @@ public class ApproovService {
      */
     public static func prefetch() {
         initializerQueue.sync {
-            if isInitialized {
+            if serviceIsInitialized && approovEnabled {
                 Approov.fetchToken({(approovResult: ApproovTokenFetchResult) in
                     if approovResult.status == ApproovTokenFetchStatus.unknownURL {
                         if loggingLevel >= .debug {
@@ -563,6 +625,12 @@ public class ApproovService {
      * @throws ApproovError if there was a problem
      */
     public static func precheck() throws {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: precheck: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "ApproovService: precheck requires Approov to be enabled")
+        }
         // try to fetch a non-existent secure string in order to check for a rejection
         let approovResults = Approov.fetchSecureStringAndWait("precheck-dummy-key", nil)
         if approovResults.status == ApproovTokenFetchStatus.unknownKey {
@@ -588,6 +656,12 @@ public class ApproovService {
      * @return String of the device ID or nil in case of an error
      */
     public static func getDeviceID() -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getDeviceID: SDK not initialized", type: .error)
+            }
+            return nil
+        }
         let deviceID = Approov.getDeviceID()
         if (deviceID != nil) {
             if loggingLevel >= .debug {
@@ -607,6 +681,12 @@ public class ApproovService {
      * @param data is the data to be hashed and set in the token
      */
     public static func setDataHashInToken(data: String) {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: setDataHashInToken: SDK not initialized", type: .error)
+            }
+            return
+        }
         if loggingLevel >= .debug {
             os_log("ApproovService: setDataHashInToken", type: .debug)
         }
@@ -627,6 +707,12 @@ public class ApproovService {
      * @throws ApproovError if there was a problem
      */
     public static func fetchToken(url: String) throws -> String {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: fetchToken: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "ApproovService: fetchToken requires Approov to be enabled")
+        }
         // fetch the Approov token
         let result: ApproovTokenFetchResult = Approov.fetchTokenAndWait(url)
         if loggingLevel >= .debug {
@@ -659,6 +745,12 @@ public class ApproovService {
      * @return String of the base64 encoded message signature
      */
     public static func getAccountMessageSignature(message: String) -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getAccountMessageSignature: SDK not initialized", type: .error)
+            }
+            return nil
+        }
         if loggingLevel >= .debug {
             os_log("ApproovService: getAccountMessageSignature", type: .debug)
         }
@@ -673,6 +765,12 @@ public class ApproovService {
      * @return String of the base64 encoded message signature
      */
     public static func getInstallMessageSignature(message: String) -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getInstallMessageSignature: SDK not initialized", type: .error)
+            }
+            return nil
+        }
         if loggingLevel >= .debug {
             os_log("ApproovService: getInstallMessageSignature", type: .debug)
         }
@@ -698,6 +796,12 @@ public class ApproovService {
      * @throws ApproovError if there was a problem
      */
     public static func fetchSecureString(key: String, newDef: String?) throws -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: fetchSecureString: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "ApproovService: fetchSecureString requires Approov to be enabled")
+        }
         // determine the type of operation as the values themselves cannot be logged
         var type = "lookup"
         if newDef != nil {
@@ -730,6 +834,12 @@ public class ApproovService {
      * @throws ApproovError if there was a problem
      */
     public static func fetchCustomJWT(payload: String) throws -> String? {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: fetchCustomJWT: SDK not initialized", type: .error)
+            }
+            throw ApproovError.permanentError(message: "ApproovService: fetchCustomJWT requires Approov to be enabled")
+        }
         // fetch the custom JWT
         let approovResult = Approov.fetchCustomJWTAndWait(payload)
         if loggingLevel >= .info {
@@ -818,9 +928,9 @@ public class ApproovService {
         }
 
         if let url = request.url {
-            if !isInitialized {
+            if !serviceIsInitialized || !approovEnabled {
                 if loggingLevel >= .info {
-                    os_log("ApproovService: not initialized, forwarding: %@", type: .info, url.absoluteString)
+                    os_log("ApproovService: not initialized or not enabled, forwarding: %@", type: .info, url.absoluteString)
                 }
                 return ApproovUpdateResponse(request: request, decision: .ShouldIgnore, sdkMessage: "", error: nil)
             }
@@ -1127,5 +1237,29 @@ public class ApproovService {
             }
         }
         return finalizeResponse()
+    }
+
+    /**
+     * Resets all service-layer state back to defaults. This is intended for testing only
+     * and should never be called in production code.
+     */
+    static func resetForTesting() {
+        initializerQueue.sync {
+            serviceIsInitialized = false
+            approovEnabled = false
+            configString = nil
+        }
+        stateQueue.sync {
+            bindingHeader = ""
+            approovTokenHeader = "Approov-Token"
+            approovTokenPrefix = ""
+            approovTraceIDHeader = "Approov-TraceID"
+            serviceMutator = ApproovServiceMutatorDefault.shared
+            substitutionHeaders = Dictionary()
+            substitutionQueryParams = Set()
+            exclusionURLRegexs = Dictionary()
+            useApproovStatusIfNoToken = false
+        }
+        loggingLevel = .info
     }
 }

--- a/Sources/ApproovSession/ApproovService.swift
+++ b/Sources/ApproovSession/ApproovService.swift
@@ -247,7 +247,7 @@ public class ApproovService {
     public static func getLastARC() -> String {
         if !isApproovEnabled() {
             if loggingLevel >= .error {
-                os_log("ApproovService: getLastARC: SDK not initialized", type: .error)
+                os_log("ApproovService: getLastARC: Approov protection not enabled", type: .error)
             }
             return ""
         }
@@ -927,7 +927,7 @@ public class ApproovService {
         }
 
         if let url = request.url {
-            if !serviceIsInitialized || !approovEnabled {
+            if !isInitialized() || !isApproovEnabled() {
                 if loggingLevel >= .info {
                     os_log("ApproovService: not initialized or not enabled, forwarding: %@", type: .info, url.absoluteString)
                 }
@@ -972,7 +972,7 @@ public class ApproovService {
         if approovResult.isConfigChanged {
             Approov.fetchConfig()
             if loggingLevel >= .info {
-                os_log("ApproovService: dynamic configuration update received")
+                os_log("ApproovService: dynamic configuration update performed")
             }
         }
 

--- a/Sources/ApproovSession/ApproovService.swift
+++ b/Sources/ApproovSession/ApproovService.swift
@@ -503,8 +503,7 @@ public class ApproovService {
      * This means that if the query parameter is present in a URL then the value will be used as a
      * key to look up a secure string value which will be substituted as the query parameter value
      * instead. This allows easy migration to the use of secure strings. Note that this function
-     * should be called on initialization rather than for every request as it will require a new
-     * OkHttpClient to be built.
+     * should be called on initialization rather than for every request.
      *
      * @param key is the query parameter key name to be added for substitution
      */

--- a/Sources/ApproovSession/ApproovService.swift
+++ b/Sources/ApproovSession/ApproovService.swift
@@ -88,11 +88,6 @@ public class ApproovService {
     // the dispatch queue to manage serial access to intializer-modified variables
     private static let initializerQueue = DispatchQueue(label: "ApproovService.initializer", qos: .userInitiated)
 
-    // configuration string used for initialization; stored to support the empty-then-valid
-    // upgrade guard. In this service layer, Approov-enabled state is tracked via the
-    // separate `approovEnabled` flag rather than by inspecting configString directly.
-    private static var configString: String?
-
     // status of service layer initialization
     private static var serviceIsInitialized = false
 
@@ -164,10 +159,33 @@ public class ApproovService {
 
     /**
      * Initializes the SDK with the config obtained using `approov sdk -getConfigString` or
-     * in the original onboarding email. The service layer resets its own configuration state
-     * on a successful call. If using a non-empty config, the platform SDK is contacted first;
-     * state is only modified after the SDK confirms success, preserving the current operating
-     * mode (protected or bypass) if the call fails.
+     * in the original onboarding email.
+     *
+     * Initialize ONCE, then configure. Every successful call RESETS all service-layer
+     * configuration — token header and prefix, binding header, trace-ID header, header and
+     * query-parameter substitutions, exclusion URL regexs, and the service mutator — back to
+     * their defaults. Any values set via `setTokenHeader` / `addSubstitutionHeader` /
+     * `addExclusionURLRegex` / `setServiceMutator` (etc.) must therefore be applied AFTER the
+     * final initialize call: re-initializing afterwards, even with the same config, silently
+     * discards them. A warning is logged when a re-initialization discards existing state.
+     *
+     * Calls are forwarded to the native Approov SDK, which is the authority on configuration
+     * identity (it compares the config, the update config AND the comment). The resulting
+     * behaviour is:
+     *   - empty config: initializes the service layer in bypass mode (native SDK not enabled);
+     *   - empty config after a valid init: ignored — no downgrade to bypass and, unlike a
+     *     valid re-initialize, the existing service-layer configuration is preserved (not reset);
+     *   - same config + same comment after a valid init: accepted as a no-op by the native SDK,
+     *     but the service layer still resets its configuration to defaults;
+     *   - same config + a different non-"reinit" comment, or a different config without a
+     *     "reinit" comment: rejected by the native SDK — an `.initializationError` is thrown and
+     *     the existing state is preserved;
+     *   - a "reinit"-prefixed comment: the native SDK reinitializes and the service layer
+     *     resets its configuration to defaults.
+     *
+     * If a non-empty config is used the native SDK is contacted first; service-layer state is
+     * only modified after the SDK confirms success, preserving the current operating mode
+     * (protected or bypass) if the call fails.
      *
      * @param config is the configuration to be used, or an empty string to bypass the actual initialization
      * @param comment is an optional comment to be passed to the SDK
@@ -175,9 +193,10 @@ public class ApproovService {
      */
     public static func initialize(config: String, comment: String? = nil) throws {
         try initializerQueue.sync {
-            // If we are already initialized with a valid config, ignore any subsequent
-            // attempt to initialize with an empty config (cannot downgrade from protected
-            // to bypass mode).
+            // Deliberate strict no-op: once protected, an empty config is ignored entirely.
+            // There is no downgrade from protected to bypass mode and — unlike a valid
+            // re-initialize — the existing service-layer configuration is preserved rather
+            // than reset to defaults (see this method's documentation for the full matrix).
             if approovEnabled && config.isEmpty {
                 if loggingLevel >= .info {
                     os_log("ApproovService: ignoring empty config after valid initialization", type: .info)
@@ -212,19 +231,14 @@ public class ApproovService {
             }
 
             // SDK succeeded (or bypass) — now reset and commit new service-layer state.
-            serviceIsInitialized = false
-            configString = config
-            stateQueue.sync {
-                bindingHeader = ""
-                approovTokenHeader = "Approov-Token"
-                approovTokenPrefix = ""
-                approovTraceIDHeader = "Approov-TraceID"
-                serviceMutator = ApproovServiceMutatorDefault.shared
-                substitutionHeaders = Dictionary()
-                substitutionQueryParams = Set()
-                exclusionURLRegexs = Dictionary()
-                useApproovStatusIfNoToken = false
+            // A successful initialize always resets the service layer's own configuration
+            // back to defaults; warn if this discards an existing (re-initialize) setup so
+            // that the unsupported "initialize again" pattern is observable.
+            if serviceIsInitialized && loggingLevel >= .warning {
+                os_log("ApproovService: re-initializing — all service-layer configuration (token header, prefixes, substitutions, exclusions, mutator) is being reset to defaults", type: .default)
             }
+            serviceIsInitialized = false
+            resetServiceConfiguration()
             serviceIsInitialized = true
             if !config.isEmpty {
                 approovEnabled = true
@@ -1241,15 +1255,12 @@ public class ApproovService {
     }
 
     /**
-     * Resets all service-layer state back to defaults. This is intended for testing only
-     * and should never be called in production code.
+     * Resets all configurable service-layer state (headers, prefixes, substitutions,
+     * exclusions and the service mutator) back to their defaults. Acquires `stateQueue`
+     * internally, so callers must not already hold it. Initialization flags
+     * (`serviceIsInitialized` / `approovEnabled`) are managed separately by the caller.
      */
-    static func resetForTesting() {
-        initializerQueue.sync {
-            serviceIsInitialized = false
-            approovEnabled = false
-            configString = nil
-        }
+    private static func resetServiceConfiguration() {
         stateQueue.sync {
             bindingHeader = ""
             approovTokenHeader = "Approov-Token"
@@ -1261,6 +1272,18 @@ public class ApproovService {
             exclusionURLRegexs = Dictionary()
             useApproovStatusIfNoToken = false
         }
+    }
+
+    /**
+     * Resets all service-layer state back to defaults. This is intended for testing only
+     * and should never be called in production code.
+     */
+    static func resetForTesting() {
+        initializerQueue.sync {
+            serviceIsInitialized = false
+            approovEnabled = false
+        }
+        resetServiceConfiguration()
         loggingLevel = .info
     }
 }

--- a/Sources/ApproovSession/ApproovService.swift
+++ b/Sources/ApproovSession/ApproovService.swift
@@ -88,7 +88,9 @@ public class ApproovService {
     // the dispatch queue to manage serial access to intializer-modified variables
     private static let initializerQueue = DispatchQueue(label: "ApproovService.initializer", qos: .userInitiated)
 
-    // configuration string used for initialization
+    // configuration string used for initialization; stored to support the empty-then-valid
+    // upgrade guard. In this service layer, Approov-enabled state is tracked via the
+    // separate `approovEnabled` flag rather than by inspecting configString directly.
     private static var configString: String?
 
     // status of service layer initialization

--- a/Sources/ApproovSession/ApproovTrustManager.swift
+++ b/Sources/ApproovSession/ApproovTrustManager.swift
@@ -151,6 +151,11 @@ public final class ApproovTrustEvaluator: ServerTrustEvaluating {
         // firstly we perform the default evaluation as it must also pass this
         try trust.af.performDefaultValidation(forHost: host)
         
+        // If the service layer is not enabled (empty-config bypass), skip dynamic pinning
+        if !ApproovService.isApproovEnabled() {
+            return
+        }
+
         // get the dynamic pins from Approov
         guard let approovPins = Approov.getPins("public-key-sha256") else {
             // just return if there are no Approov pins (this can happen if Approov is not initialized)
@@ -255,6 +260,9 @@ public class ApproovTrustManager: ServerTrustManager {
      * @return the ServerTrustEvaluating policy to be used
      */
     public override func serverTrustEvaluator(forHost host: String) throws -> ServerTrustEvaluating? {
+        if !ApproovService.isApproovEnabled() {
+            return try super.serverTrustEvaluator(forHost: host)
+        }
         if let approovPins = Approov.getPins("public-key-sha256") {
             // if Approov dynamic pins are available then we always use them for domains added to Approov
             if approovPins.keys.contains(host) {

--- a/Tests/ApproovAFSessionMiniSDKTests/ApproovAFSessionMiniSDKTests.swift
+++ b/Tests/ApproovAFSessionMiniSDKTests/ApproovAFSessionMiniSDKTests.swift
@@ -47,8 +47,8 @@ final class ApproovAFSessionMiniSDKTests: XCTestCase {
         XCTAssertFalse(ApproovService.isApproovEnabled())
     }
 
-    /// §1 Empty Configuration (Empty Comment)
-    func testInitializeWithEmptyConfigEmptyComment() throws {
+    /// §1 Empty Configuration (Nil Comment — distinct from empty-string comment per TESTING_REQUIREMENTS §1)
+    func testInitializeWithEmptyConfigNilComment() throws {
         ApproovService.resetForTesting()
         try ApproovService.initialize(config: "", comment: nil)
         XCTAssertTrue(ApproovService.isInitialized())

--- a/Tests/ApproovAFSessionMiniSDKTests/ApproovAFSessionMiniSDKTests.swift
+++ b/Tests/ApproovAFSessionMiniSDKTests/ApproovAFSessionMiniSDKTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+import Foundation
+@testable import ApproovAFSession
+import Approov
+import MiniSDKTestSupport
+
+/// Integration tests for the ApproovService Alamofire service layer.
+///
+/// Tests are organized to match the sections defined in TESTING_REQUIREMENTS.md
+/// from the core-service-layers-testing repository.
+///
+/// - SeeAlso: `TESTING_REQUIREMENTS.md` in core-service-layers-testing
+final class ApproovAFSessionMiniSDKTests: XCTestCase {
+    private let validInitialConfig = "#cb-ivol#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo="
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MiniSDKAttesterProxyController.reset()
+        ApproovService.resetForTesting()
+        ApproovService.setLoggingLevel(.off)
+        try ApproovService.initialize(config: validInitialConfig, comment: "reinit-alamofire-tests")
+    }
+
+    override func tearDown() {
+        ApproovService.setServiceMutator(nil)
+        MiniSDKAttesterProxyController.reset()
+        ApproovService.resetForTesting()
+        super.tearDown()
+    }
+
+    // MARK: - §1 Initialization
+    // TESTING_REQUIREMENTS.md §1
+
+    /// §1 Valid Configuration
+    func testInitializeWithValidConfig() throws {
+        ApproovService.resetForTesting()
+        try ApproovService.initialize(config: validInitialConfig, comment: nil)
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+    }
+
+    /// §1 Empty Configuration (Valid Comment)
+    func testInitializeWithEmptyConfigBypassMode() throws {
+        ApproovService.resetForTesting()
+        try ApproovService.initialize(config: "", comment: "some-comment")
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertFalse(ApproovService.isApproovEnabled())
+    }
+
+    /// §1 Empty Configuration (Empty Comment)
+    func testInitializeWithEmptyConfigEmptyComment() throws {
+        ApproovService.resetForTesting()
+        try ApproovService.initialize(config: "", comment: nil)
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertFalse(ApproovService.isApproovEnabled())
+    }
+
+    /// §1 Empty Then Valid Configuration
+    func testInitializeEmptyThenValidUpgrade() throws {
+        ApproovService.resetForTesting()
+        try ApproovService.initialize(config: "", comment: nil)
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertFalse(ApproovService.isApproovEnabled())
+
+        try ApproovService.initialize(config: validInitialConfig, comment: nil)
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+    }
+
+    /// §1 Empty Configuration after Valid Configuration
+    func testInitializeValidThenEmptyIgnored() throws {
+        ApproovService.resetForTesting()
+        try ApproovService.initialize(config: validInitialConfig, comment: nil)
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+
+        // This should be silently ignored
+        try ApproovService.initialize(config: "", comment: nil)
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+    }
+
+    /// §1 Same Config Re-initialization
+    func testInitializeSameConfigReinit() throws {
+        XCTAssertNoThrow(try ApproovService.initialize(config: validInitialConfig, comment: nil))
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+    }
+
+    /// §1 Different Non-empty Config Re-initialization
+    func testInitializeDifferentConfigRejectsAndPreservesState() throws {
+        let differentConfig = "#cb-other#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo="
+        XCTAssertThrowsError(try ApproovService.initialize(config: differentConfig, comment: nil)) { error in
+            guard case ApproovError.initializationError = error else {
+                return XCTFail("Expected initializationError, got \(error)")
+            }
+        }
+        // State must be preserved from the original initialization
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertTrue(ApproovService.isApproovEnabled())
+    }
+
+    /// §1 Service Mutator Reset
+    func testInitializeResetsMutatorToDefault() throws {
+        struct TestMutator: ApproovServiceMutator {}
+        ApproovService.setServiceMutator(TestMutator())
+        XCTAssertTrue(ApproovService.getServiceMutator() is TestMutator)
+
+        try ApproovService.initialize(config: validInitialConfig, comment: "reinit-mutator-test")
+        XCTAssertTrue(ApproovService.getServiceMutator() is ApproovServiceMutatorDefault)
+    }
+
+    /// §1 SDK and Service Layer Initialization Behaviour — guards
+    func testSDKMethodsGuardedWhenNotEnabled() throws {
+        ApproovService.resetForTesting()
+        try ApproovService.initialize(config: "", comment: nil)
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertFalse(ApproovService.isApproovEnabled())
+
+        // These should return nil/empty without calling the SDK
+        XCTAssertEqual(ApproovService.getLastARC(), "")
+        XCTAssertNil(ApproovService.getDeviceID())
+        XCTAssertNil(ApproovService.getAccountMessageSignature(message: "test"))
+        XCTAssertNil(ApproovService.getInstallMessageSignature(message: "test"))
+
+        // These should throw
+        XCTAssertThrowsError(try ApproovService.precheck())
+        XCTAssertThrowsError(try ApproovService.fetchToken(url: "https://example.com"))
+        XCTAssertThrowsError(try ApproovService.fetchSecureString(key: "test", newDef: nil))
+        XCTAssertThrowsError(try ApproovService.fetchCustomJWT(payload: "{}"))
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the `initialize(config:comment:)` API with options support, service layer bypass mode, comprehensive initialization guard improvements, and an Approov service mutator pattern for the Alamofire service layer.

### Changes

#### Core Service Layer (`ApproovService.swift`)
- **Initialize with options**: `initialize(config:comment:)` now accepts an optional `comment` parameter forwarded directly to the native SDK (supports `options:...` startup flags and `reinit...` flows)
- **Bypass mode**: Passing an empty `config` string initializes the service layer without enabling the native Approov SDK. A subsequent call with a valid config upgrades to protected mode
- **Commit-last pattern**: Service-layer state is only modified after the SDK confirms success, preserving the current operating mode on failure
- **Valid-then-empty guard**: Once initialized with a valid config, subsequent empty-config calls are silently ignored (no downgrade from protected to bypass mode)
- **`isInitialized()`**: New public API exposing service-layer initialization state (distinct from `isApproovEnabled()`)

#### Trust Manager (`ApproovTrustManager.swift` / `ApproovTrustEvaluator.swift`)
- OS-level certificate validation always runs via `performDefaultValidation`, even in bypass mode
- Dynamic pinning skipped in bypass mode; Approov pins applied only when `isApproovEnabled()`

#### Tests
- Mini-SDK integration tests covering §1 initialization scenarios: valid config, empty config, empty→valid upgrade, valid→empty (ignored), same-config reinit, different-config rejection with state preservation, mutator reset, and SDK method guards in bypass mode

#### Documentation & Policy
- `SECURITY.md`: corrected grammar, clarified supported version table (`< 3.5.0 (3.4.0)` marked unsupported)
- `ApproovService.swift`: removed stale Android/OkHttpClient reference from doc comment

### Supersedes / Incorporates
- PR #24 (`naynovi:patch-1`): SECURITY.md improvements — all changes already present in this branch
- PR #25 (`feature/3.6.0`): SECURITY.md additions — already merged

### Testing
All §1 initialization scenarios covered by `ApproovAFSessionMiniSDKTests`. Run with:
```
APPROOV_USE_MINI_SDK=1 APPROOV_MINI_SDK_PATH=../core-service-layers-testing/mini-sdk/ios swift test
```

Related: approov/core-project-approov#559
