### PR TITLE
chore: bump version to 3.5.6, add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this package will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
 
+## [3.5.6] - 2026-06-12
+
+### Added
+- `initialize(config:comment:)` now accepts an optional `comment` parameter forwarded to the native SDK, supporting `options:` startup flags and `reinit` flows.
+- Bypass mode: passing an empty `config` string initializes the service layer without enabling the native Approov SDK; a subsequent call with a valid config upgrades to protected mode.
+- `isInitialized()` public API exposing service-layer initialization state (distinct from `isApproovEnabled()`).
+- `SECURITY.md` with version support table and vulnerability reporting instructions.
+- GitHub Actions CI workflow (`build_and_test.yml`) for automated builds and mini-SDK contract tests.
+- Mini-SDK integration tests covering §1 initialization scenarios: valid config, empty config, empty→valid upgrade, valid→empty (ignored), same-config reinit, different-config rejection with state preservation, mutator reset, and SDK method guards in bypass mode.
+
+### Changed
+- Commit-last initialization pattern: service-layer state is only modified after the SDK confirms success, preserving the current operating mode on failure.
+- Valid-then-empty guard: once initialized with a valid config, subsequent empty-config calls are silently ignored (no downgrade from protected to bypass mode).
+- Trust manager performs OS-level certificate validation (`performDefaultValidation`) even in bypass mode; dynamic pinning skipped when SDK is not enabled.
+
+### Fixed
+- Removed stale Android/OkHttpClient reference from `ApproovService.swift` doc comment.
+- Corrected grammar and clarified supported version table in `SECURITY.md`.
+
 ## [3.5.5] - 2026-03-06
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 // Release tag
-let releaseTAG = "3.5.5"
+let releaseTAG = "3.5.6"
 // SDK package version (used for both iOS and watchOS)
 let sdkVersion: Version = "3.5.3"
 let useMiniSDK = ProcessInfo.processInfo.environment["APPROOV_USE_MINI_SDK"] == "1"


### PR DESCRIPTION
Bump `releaseTAG` to 3.5.6 in Package.swift and add CHANGELOG.md entry covering all changes merged from `feature/initialize-with-options` (PR #26):

- `initialize(config:comment:)` with options support
- Service layer bypass mode
- Commit-last initialization pattern
- Trust manager OS-level validation in bypass mode
- GitHub Actions CI workflow
- SECURITY.md
- Mini-SDK integration tests (§1 initialization)

Related: approov/core-project-approov#559